### PR TITLE
Added compilemessages task for djpl

### DIFF
--- a/django_productline/features/multilanguage/settings.py
+++ b/django_productline/features/multilanguage/settings.py
@@ -5,10 +5,6 @@ from __future__ import unicode_literals
 def refine_INSTALLED_APPS(original):
     return ['django_productline.features.multilanguage'] + list(original)
 
-introduce_LANGUAGES = [
-    ('en', 'English')
-]
-
 # Just make sure that the default djpl settings weren't overridden
 refine_USE_I18N = True
 

--- a/django_productline/settings.py
+++ b/django_productline/settings.py
@@ -34,6 +34,10 @@ TIME_ZONE = 'America/Chicago'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
+LANGUAGES = [
+    ('en', 'English')
+]
+
 SITE_ID = PRODUCT_CONTEXT.SITE_ID
 
 # If you set this to False, Django will make some optimizations so as not

--- a/django_productline/tasks.py
+++ b/django_productline/tasks.py
@@ -108,6 +108,36 @@ def deploy():
     :return:
     """
     print('... processing deploy tasks')
+    tasks.djpl_compilemessages()
+
+
+@tasks.register
+@tasks.requires_product_environment
+def djpl_compilemessages():
+    """
+    Compile messages hook for django_productline, this task checks for the activated languages
+    in settings.LANGUAGES. It runs the standard django compilemessages management command with the -l parameter.
+    Example language setting:
+        LANGUAGES = [
+            ('de', 'Deutsch'),
+            ('en', 'English')
+        ]
+    Remarks:
+        - Each argument for the management command MUST be a single list item, e.g. ['compilemessages', '--locale', 'en']
+        - The compilemessages command MUST be executed in the projects root dir, so the CWD is adjusted before running this command.
+    :return:
+    """
+    from django.conf import settings
+    if hasattr(settings, 'LANGUAGES') and len(settings.LANGUAGES) > 0:
+        # changing cwd to project root
+        os.chdir(os.path.join(os.environ['APE_ROOT_DIR'], os.environ['CONTAINER_NAME']))
+        languages = list()
+        for language in settings.LANGUAGES:
+            languages.append(language[0])
+        args = ['compilemessages']
+        for lang in languages:
+            args.extend(['--locale', str(lang)])
+        tasks.manage(*args)
 
 
 @tasks.register

--- a/django_productline/tasks.py
+++ b/django_productline/tasks.py
@@ -119,8 +119,8 @@ def djpl_compilemessages():
     in settings.LANGUAGES. It runs the standard django compilemessages management command with the -l parameter.
     Example language setting:
         LANGUAGES = [
-            ('de', 'Deutsch'),
-            ('en', 'English')
+            ('en', 'English'),
+            ('de', 'Deutsch')
         ]
     Remarks:
         - Each argument for the management command MUST be a single list item, e.g. ['compilemessages', '--locale', 'en']
@@ -132,9 +132,11 @@ def djpl_compilemessages():
         # changing cwd to project root
         os.chdir(os.path.join(os.environ['APE_ROOT_DIR'], os.environ['CONTAINER_NAME']))
         languages = list()
+        # collect the language abbreviations
         for language in settings.LANGUAGES:
             languages.append(language[0])
         args = ['compilemessages']
+        # extend the arg list by the -locale argument for each language
         for lang in languages:
             args.extend(['--locale', str(lang)])
         tasks.manage(*args)


### PR DESCRIPTION
Therefore, I had to change the introduction of LANGUAGES setting, because django has default enabled all languages (We shouldn't compile all languages as we run this task, only the explicitly activated ones).
