### PR TITLE
added refinable fallback_urls

### DIFF
--- a/django_productline/features/multilanguage/settings.py
+++ b/django_productline/features/multilanguage/settings.py
@@ -14,32 +14,23 @@ refine_USE_I18N = True
 
 refine_USE_L10N = True
 
-"""
-Django docs say that the LocaleMiddleware should come after the SessionMiddleware.
-Here, we make sure that the SessionMiddleware is enabled and then place the
-LocaleMiddleware at the correct position.
-Be careful with the order when refining the MiddlewareClasses with following features.
-:param original:
-:return:
-"""
-# Since version 1.10 MIDDLEWARE_CLASSES is deprecated, since 2.0 its been removed
-if compare_version(django.get_version(), '1.10') >= 0:
-    def refine_MIDDLEWARE(original):
-        try:
-            session_middleware_index = original.index('django.contrib.sessions.middleware.SessionMiddleware')
-            original.insert(session_middleware_index + 1, 'django.middleware.locale.LocaleMiddleware')
-            return original
-        except ValueError:
-            raise LookupError('SessionMiddleware not found! Please make sure you have enabled the \
-             SessionMiddleware in your settings (django.contrib.sessions.middleware.SessionMiddleware).')
-else:
-    def refine_MIDDLEWARE_CLASSES(original):
-        try:
-            session_middleware_index = original.index('django.contrib.sessions.middleware.SessionMiddleware')
-            original.insert(session_middleware_index + 1, 'django.middleware.locale.LocaleMiddleware')
-            return original
-        except ValueError:
-            raise LookupError('SessionMiddleware not found! Please make sure you have enabled the \
-             SessionMiddleware in your settings (django.contrib.sessions.middleware.SessionMiddleware).')
+
+def refine_MIDDLEWARE_CLASSES(original):
+    """
+    Django docs say that the LocaleMiddleware should come after the SessionMiddleware.
+    Here, we make sure that the SessionMiddleware is enabled and then place the
+    LocaleMiddleware at the correct position.
+    Be careful with the order when refining the MiddlewareClasses with following features.
+    :param original:
+    :return:
+    """
+    try:
+        session_middleware_index = original.index('django.contrib.sessions.middleware.SessionMiddleware')
+        original.insert(session_middleware_index + 1, 'django.middleware.locale.LocaleMiddleware')
+        return original
+    except ValueError:
+        raise LookupError('SessionMiddleware not found! Please make sure you have enabled the \
+         SessionMiddleware in your settings (django.contrib.sessions.middleware.SessionMiddleware).')
+
 
 introduce_PREFIX_DEFAULT_LANGUAGE = True

--- a/django_productline/features/multilanguage_switcher/urls.py
+++ b/django_productline/features/multilanguage_switcher/urls.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 
-def refine_get_urls(original):
-    def get_urls():
+def refine_get_multilang_urls(original):
+    def get_multilang_urls():
         from django.conf.urls import url
         from .views import ChangeLangView
 
@@ -11,4 +11,4 @@ def refine_get_urls(original):
         ]
         return urlpatterns + original()
 
-    return get_urls
+    return get_multilang_urls

--- a/django_productline/root_urlconf.py
+++ b/django_productline/root_urlconf.py
@@ -11,4 +11,4 @@ Django uses these to construct the root RegexUrlResolver.
 
 from django_productline import urls
 
-urlpatterns = urls.get_urls()
+urlpatterns = urls.get_urls() + urls.get_fallback_urls()

--- a/django_productline/urls.py
+++ b/django_productline/urls.py
@@ -40,5 +40,20 @@ def get_urls():
     return []
 
 
+def get_fallback_urls():
+    """
+    refine this to add special fallback urlpatterns.
+    These urls will be appended to the end of the url patterns list (after 'get_urls()' in root_urlconf).
+    E.g.:
+
+        url(r'^foo/$', views.foo),
+        url(r'^bar/(\d{4})/$', views.bar),
+        # This url 'catches' all other requests which don't match the previous patterns.
+        url(r'^.*', views.catch_all),
+
+    """
+    return []
+
+
 handler404 = 'django.views.defaults.page_not_found'
 handler500 = 'django.views.defaults.server_error'


### PR DESCRIPTION
removed non working django 1.10+ middleware compatibility from multilanguage
adjusted multilangauge_switcher urls to refine get_multilang_urls instead of get_urls